### PR TITLE
feat(BE-114): added endpoints to for applicant to view list of applic…

### DIFF
--- a/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/controller/ApplicantController.java
+++ b/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/controller/ApplicantController.java
@@ -1,0 +1,38 @@
+package com.hydraulic.applyforme.controller;
+
+import com.hydraulic.applyforme.model.response.base.ApplyForMeResponse;
+import com.hydraulic.applyforme.service.ApplicantService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.hydraulic.applyforme.constants.PagingConstants.*;
+import static com.hydraulic.applyforme.constants.PagingConstants.DEFAULT_SORT_DIRECTION;
+
+@RestController
+@RequestMapping(
+        value = "applicant",
+        produces = { MediaType.APPLICATION_JSON_VALUE }
+)
+public class ApplicantController {
+
+    private final ApplicantService service;
+
+    @Autowired
+    public ApplicantController(ApplicantService service) {
+        this.service = service;
+    }
+
+
+    @GetMapping("/entries")
+    public ApplyForMeResponse getAllSubmission(
+            @RequestParam(value = "pageNo", defaultValue = DEFAULT_PAGE_NUMBER, required = false) int pageNo,
+            @RequestParam(value = "pageSize", defaultValue = DEFAULT_PAGE_SIZE, required = false) int pageSize,
+            @RequestParam(value = "sortBy", defaultValue = DEFAULT_SORT_BY, required = false) String sortBy,
+            @RequestParam(value = "sortDir", defaultValue = DEFAULT_SORT_DIRECTION, required = false) String sortDir) {
+        return service.getApplicationList(pageNo, pageSize, sortBy, sortDir);
+    }
+}

--- a/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/model/dto/applicant/ApplicantResponse.java
+++ b/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/model/dto/applicant/ApplicantResponse.java
@@ -1,0 +1,19 @@
+package com.hydraulic.applyforme.model.dto.applicant;
+
+import lombok.*;
+
+import java.util.Date;
+
+@Getter @Setter
+@AllArgsConstructor @RequiredArgsConstructor
+@Builder
+public class ApplicantResponse {
+
+    private Long id;
+    private String jobCompany;
+    private String jobTitle;
+    private String jobLocation;
+    private String jobType;
+    private String salaryRange;
+    private Date date;
+}

--- a/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/service/ApplicantService.java
+++ b/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/service/ApplicantService.java
@@ -1,0 +1,8 @@
+package com.hydraulic.applyforme.service;
+
+import com.hydraulic.applyforme.model.response.base.ApplyForMeResponse;
+
+public interface ApplicantService {
+
+    ApplyForMeResponse getApplicationList(int pageNo, int pageSize, String sortBy, String sortDir);
+}

--- a/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/service/impl/ApplicantServiceImpl.java
+++ b/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/service/impl/ApplicantServiceImpl.java
@@ -1,0 +1,53 @@
+package com.hydraulic.applyforme.service.impl;
+
+import com.hydraulic.applyforme.model.dto.applicant.ApplicantResponse;
+import com.hydraulic.applyforme.model.response.base.ApplyForMeResponse;
+import com.hydraulic.applyforme.repository.jpa.JobSubmissionRepository;
+import com.hydraulic.applyforme.service.ApplicantService;
+import com.hydraulic.applyforme.util.ApplyForMeUtil;
+import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+@Service
+public class ApplicantServiceImpl implements ApplicantService {
+
+
+    private final JobSubmissionRepository jobSubmissionRepository;
+
+    private final ModelMapper modelMapper;
+
+    public ApplicantServiceImpl(JobSubmissionRepository jobSubmissionRepository, ModelMapper modelMapper) {
+        this.jobSubmissionRepository = jobSubmissionRepository;
+        this.modelMapper = modelMapper;
+    }
+
+
+    @Override
+    public ApplyForMeResponse getApplicationList(int pageNo, int pageSize, String sortBy, String sortDir) {
+        Pageable pageable =  ApplyForMeUtil.createPageable(pageNo, pageSize, sortBy, sortDir);
+        var result =  jobSubmissionRepository.findAll(pageable);
+
+        Collection<ApplicantResponse> applicantResponse = result.getContent().stream().map(x -> ApplicantResponse.builder()
+                .id(x.getId())
+                .date(x.getCreatedOn())
+                .jobLocation(x.getJobLocation())
+                .jobTitle(x.getJobTitle())
+                .jobType(x.getJobLocationType().getValue())
+                .jobCompany(x.getJobCompany())
+                .salaryRange("I don't know where to find it, I can't even do a join table")
+                .build()
+        ).collect(Collectors.toList());
+        ApplyForMeResponse applyForMeResponse = new ApplyForMeResponse();
+        applyForMeResponse.setContent(applicantResponse);
+        applyForMeResponse.setPageSize(result.getSize());
+        applyForMeResponse.setTotalElements(result.getTotalElements());
+        applyForMeResponse.setPageNo(result.getNumber());
+        applyForMeResponse.setTotalPages(result.getTotalPages());
+        applyForMeResponse.setLast(result.isLast());
+        return applyForMeResponse;
+    }
+}


### PR DESCRIPTION
Issues:

- As an applicant, I should be able to view the list of applications, paginate through them and sort by date in Ascending and Descending order
- https://linear.app/team-hydraulics/issue/BAC-114/applicant-view-list-of-applications

What has changed:

- Add a method to theApplicant Controller class

- Add getApplicabtList method to the SuperAdminApplierService class and it's corresponding implementation

What reviews should know:
- Map ApplierObject to HighestApplier object to avoid avoid infinite recursion

Live Link:

- https://api.applyforme.hng.tech/api/v1/applicant/entries?sortBy=createdOn

- You can sortBy Id, createdOn, jobTitle, JobComapany by passing this keywords as the request params i.e sortBy = id
- You can also sort either in ascending or descending order using sortDir=asc or sortDir=desc