### PR TITLE
Feat/be onboarding new user

### DIFF
--- a/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/controller/OnboardingController.java
+++ b/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/controller/OnboardingController.java
@@ -1,5 +1,7 @@
 package com.hydraulic.applyforme.controller;
 
+import com.hydraulic.applyforme.model.domain.Member;
+import com.hydraulic.applyforme.model.dto.admin.NewPasswordDto;
 import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -33,8 +35,8 @@ public class OnboardingController {
 		return service.onboard(body);
 	}
 	
-	@PutMapping("/{id}/registration")
-	public boolean changePassword(@PathVariable("id") Long id, @Validated @RequestBody UpdatePasswordDto body) {
-		return service.changePassword(id, body);
+	@PutMapping("/{token}/complete-onboard")
+	public Member changePassword(@PathVariable("token") String onboardToken, @Validated @RequestBody NewPasswordDto body) {
+		return service.changePassword(onboardToken, body);
 	}
 }

--- a/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/controller/OnboardingController.java
+++ b/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/controller/OnboardingController.java
@@ -2,12 +2,15 @@ package com.hydraulic.applyforme.controller;
 
 import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.hydraulic.applyforme.model.dto.TryItNowDTO;
+import com.hydraulic.applyforme.model.dto.admin.UpdatePasswordDto;
 import com.hydraulic.applyforme.model.response.OnboardingResponse;
 import com.hydraulic.applyforme.service.OnboardingService;
 
@@ -28,5 +31,10 @@ public class OnboardingController {
 	@PostMapping("/onboard")
 	public OnboardingResponse onboard(@Validated @RequestBody TryItNowDTO body) {
 		return service.onboard(body);
+	}
+	
+	@PutMapping("/{id}/registration")
+	public boolean changePassword(@PathVariable("id") Long id, @Validated @RequestBody UpdatePasswordDto body) {
+		return service.changePassword(id, body);
 	}
 }

--- a/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/controller/OnboardingController.java
+++ b/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/controller/OnboardingController.java
@@ -1,0 +1,32 @@
+package com.hydraulic.applyforme.controller;
+
+import org.springframework.http.MediaType;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.hydraulic.applyforme.model.dto.TryItNowDTO;
+import com.hydraulic.applyforme.model.response.OnboardingResponse;
+import com.hydraulic.applyforme.service.OnboardingService;
+
+@RestController
+@RequestMapping(
+        value = "visitor",
+        produces = { MediaType.APPLICATION_JSON_VALUE }
+)
+public class OnboardingController {
+
+	public final OnboardingService service;
+	
+	public OnboardingController(OnboardingService service) {
+		super();
+		this.service = service;
+	}
+
+	@PostMapping("/onboard")
+	public OnboardingResponse onboard(@Validated @RequestBody TryItNowDTO body) {
+		return service.onboard(body);
+	}
+}

--- a/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/controller/SalaryRangeController.java
+++ b/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/controller/SalaryRangeController.java
@@ -28,6 +28,11 @@ public class SalaryRangeController {
         return service.findAll(pageNumber);
     }
 
+    @GetMapping("/entries/all")
+    public List<SalaryRange> findAll() {
+        return service.findAll();
+    }
+
     @GetMapping("/detail/{id}")
     public SalaryRange findOne(@PathVariable(name ="id") Long id) {
         return service.findOne(id);

--- a/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/model/domain/Member.java
+++ b/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/model/domain/Member.java
@@ -158,6 +158,9 @@ public class Member {
     )
     private Set<Role> roles = new HashSet<>();
 
+    @Column(name = "onboard_token")
+    private String onboardToken = null;
+
     public void addRole(Role role) {
         this.getRoles().add(role);
     }

--- a/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/model/dto/TryItNowDTO.java
+++ b/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/model/dto/TryItNowDTO.java
@@ -1,13 +1,19 @@
 package com.hydraulic.applyforme.model.dto;
 
+import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hydraulic.applyforme.annotation.EmploymentTypeAnnotation;
+import com.hydraulic.applyforme.annotation.JobLocationTypeAnnotation;
+import com.hydraulic.applyforme.annotation.JobSeniorityAnnotation;
+import com.hydraulic.applyforme.annotation.PhoneNumber;
 import com.hydraulic.applyforme.model.enums.EmploymentType;
 
+import com.hydraulic.applyforme.model.enums.JobLocationType;
+import com.hydraulic.applyforme.model.enums.JobSeniority;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -15,19 +21,23 @@ import lombok.Setter;
 @Setter
 public class TryItNowDTO {
 
-    @JsonProperty("id")
-    private Long id;
-
     @JsonProperty("first_name")
+    @NotNull(message = "member.firstName.notNull")
     private String firstName;
 
     @JsonProperty("last_name")
+    @NotNull(message = "member.lastName.notNull")
     private String lastName;
     
     @JsonProperty("email_address")
+    @NotNull(message = "{member.email.notNull}")
+    @NotBlank(message = "{member.email.notBlank}")
+    @Email(message = "{member.email.valid}")
     private String emailAddress;
     
     @JsonProperty("phone_number")
+    @NotNull(message = "{member.phoneNumber.notNull}")
+    @PhoneNumber
     private String phoneNumber;
 	
     @NotNull(message = "{professionalProfile.jobTitle.notNull}")
@@ -51,6 +61,18 @@ public class TryItNowDTO {
     @EmploymentTypeAnnotation(enumClass = EmploymentType.class, message = "{professionalProfile.employmentType.enum}")
     @JsonProperty("employment_type")
     private String employmentType;
+
+    @NotNull(message = "{professionalProfile.jobLocationType.notNull}")
+    @NotBlank(message = "{professionalProfile.jobLocationType.notNull}")
+    @JobLocationTypeAnnotation(enumClass = JobLocationType.class, message = "{professionalProfile.jobLocationType.enum}")
+    @JsonProperty("job_location_type")
+    private String preferredJobLocationType;
+
+    @NotNull(message = "{professionalProfile.jobSeniority.notNull}")
+    @NotBlank(message = "{professionalProfile.jobSeniority.notNull}")
+    @JobSeniorityAnnotation(enumClass = JobSeniority.class, message = "{professionalProfile.jobSeniority.enum}")
+    @JsonProperty("job_seniority")
+    private String jobSeniority;
     
     @Size(min = 1, max = 400, message = "{professionalProfile.desiredJobTitle.size}")
     @JsonProperty("desired_job_title")

--- a/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/model/dto/TryItNowDTO.java
+++ b/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/model/dto/TryItNowDTO.java
@@ -1,0 +1,61 @@
+package com.hydraulic.applyforme.model.dto;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.hydraulic.applyforme.annotation.EmploymentTypeAnnotation;
+import com.hydraulic.applyforme.model.enums.EmploymentType;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TryItNowDTO {
+
+    @JsonProperty("id")
+    private Long id;
+
+    @JsonProperty("first_name")
+    private String firstName;
+
+    @JsonProperty("last_name")
+    private String lastName;
+    
+    @JsonProperty("email_address")
+    private String emailAddress;
+    
+    @JsonProperty("phone_number")
+    private String phoneNumber;
+	
+    @NotNull(message = "{professionalProfile.jobTitle.notNull}")
+    @NotBlank(message = "{professionalProfile.jobTitle.notNull}")
+    @Size(min = 1, max = 400, message = "{professionalProfile.jobTitle.size}")
+    @JsonProperty("job_title")
+    private String profileTitle;
+    
+    @Size(min = 1, max = 5000, message = "{professionalProfile.jobLocation.size}")
+    @JsonProperty("job_location")
+    private String jobLocation;
+    
+    @NotNull(message = "{professionalProfile.salaryRange.notNull}")
+    @NotBlank(message = "{professionalProfile.salaryRange.notNull}")
+    @Size(min = 1, max = 100, message = "{professionalProfile.salaryRange.size}")
+    @JsonProperty("salary_range")
+    private String salaryRange = "0";
+
+    @NotNull(message = "{professionalProfile.employmentType.notNull}")
+    @NotBlank(message = "{professionalProfile.employmentType.notNull}")
+    @EmploymentTypeAnnotation(enumClass = EmploymentType.class, message = "{professionalProfile.employmentType.enum}")
+    @JsonProperty("employment_type")
+    private String employmentType;
+    
+    @Size(min = 1, max = 400, message = "{professionalProfile.desiredJobTitle.size}")
+    @JsonProperty("desired_job_title")
+    private String desiredJobTitle;
+    
+    @JsonProperty("years_of_experience")
+    private Integer yearsOfExperience = 0;
+}

--- a/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/model/dto/admin/NewPasswordDto.java
+++ b/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/model/dto/admin/NewPasswordDto.java
@@ -1,0 +1,28 @@
+package com.hydraulic.applyforme.model.dto.admin;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NewPasswordDto {
+
+
+    @NotNull(message = "{member.password.notNull}")
+    @Size(min = 8, message = "{member.password.size}")
+    @JsonProperty("new_password")
+    private String newPassword;
+
+    @NotNull(message = "{member.password.notNull}")
+    @Size(min = 8, message = "{member.password.size}")
+    @JsonProperty("confirmation_password")
+    private String confirmationPassword;
+}

--- a/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/model/exception/PasswordMismatchException.java
+++ b/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/model/exception/PasswordMismatchException.java
@@ -4,7 +4,7 @@ public class PasswordMismatchException extends ApplyForMeException {
 
 	@Override
 	public String getMessage() {
-		return "New password and existing password should match.";
+		return "New password and existing or confirmation password should match.";
 	}
 
 }

--- a/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/model/response/OnboardingResponse.java
+++ b/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/model/response/OnboardingResponse.java
@@ -1,0 +1,36 @@
+package com.hydraulic.applyforme.model.response;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.hydraulic.applyforme.annotation.EmploymentTypeAnnotation;
+import com.hydraulic.applyforme.model.domain.Member;
+import com.hydraulic.applyforme.model.domain.Professional;
+import com.hydraulic.applyforme.model.enums.EmploymentType;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class OnboardingResponse {
+
+    private Long id;
+    private String firstName;
+    private String lastName;
+    private String emailAddress;
+    private String phoneNumber;
+    private String profileTitle;
+    private String jobLocation;
+    private String salaryRange = "0";
+    private String employmentType;
+    private Integer yearsOfExperience = 0;
+}

--- a/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/repository/OnboardingRepository.java
+++ b/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/repository/OnboardingRepository.java
@@ -1,0 +1,11 @@
+package com.hydraulic.applyforme.repository;
+
+import com.hydraulic.applyforme.model.domain.Member;
+import com.hydraulic.applyforme.model.domain.ProfessionalProfile;
+import com.hydraulic.applyforme.model.dto.TryItNowDTO;
+
+public interface OnboardingRepository {
+
+	Member onboardMember(TryItNowDTO body);
+	ProfessionalProfile onboardProfile(TryItNowDTO body);
+}

--- a/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/repository/impl/OnboardingRepositoryImpl.java
+++ b/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/repository/impl/OnboardingRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.hydraulic.applyforme.repository.impl;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import com.hydraulic.applyforme.model.domain.Member;
+import com.hydraulic.applyforme.model.domain.ProfessionalProfile;
+import com.hydraulic.applyforme.model.dto.TryItNowDTO;
+import com.hydraulic.applyforme.repository.OnboardingRepository;
+
+public class OnboardingRepositoryImpl implements OnboardingRepository {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+	
+	@Override
+	public Member onboardMember(TryItNowDTO body) {
+		
+		Member member = new Member();
+		
+		
+		return null;
+	}
+
+	@Override
+	public ProfessionalProfile onboardProfile(TryItNowDTO body) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+}

--- a/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/repository/jpa/MemberJpaRepository.java
+++ b/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/repository/jpa/MemberJpaRepository.java
@@ -14,4 +14,5 @@ public interface MemberJpaRepository extends JpaRepository<Member, Long> {
     boolean existsByEmailAddress(String emailAddress);
     Member findByUsername(String username);
     Member findByPhoneNumber(String phoneNumber);
+    Member findByOnboardToken(String onboardToken);
 }

--- a/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/service/OnboardingService.java
+++ b/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/service/OnboardingService.java
@@ -1,0 +1,9 @@
+package com.hydraulic.applyforme.service;
+
+import com.hydraulic.applyforme.model.dto.TryItNowDTO;
+import com.hydraulic.applyforme.model.response.OnboardingResponse;
+
+public interface OnboardingService {
+
+	public OnboardingResponse onboard(TryItNowDTO body);
+}

--- a/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/service/OnboardingService.java
+++ b/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/service/OnboardingService.java
@@ -1,11 +1,13 @@
 package com.hydraulic.applyforme.service;
 
+import com.hydraulic.applyforme.model.domain.Member;
 import com.hydraulic.applyforme.model.dto.TryItNowDTO;
+import com.hydraulic.applyforme.model.dto.admin.NewPasswordDto;
 import com.hydraulic.applyforme.model.dto.admin.UpdatePasswordDto;
 import com.hydraulic.applyforme.model.response.OnboardingResponse;
 
 public interface OnboardingService {
 
 	OnboardingResponse onboard(TryItNowDTO body);
-	boolean changePassword(Long id, UpdatePasswordDto body);
+	Member changePassword(String onboardToken, NewPasswordDto body);
 }

--- a/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/service/OnboardingService.java
+++ b/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/service/OnboardingService.java
@@ -1,9 +1,11 @@
 package com.hydraulic.applyforme.service;
 
 import com.hydraulic.applyforme.model.dto.TryItNowDTO;
+import com.hydraulic.applyforme.model.dto.admin.UpdatePasswordDto;
 import com.hydraulic.applyforme.model.response.OnboardingResponse;
 
 public interface OnboardingService {
 
-	public OnboardingResponse onboard(TryItNowDTO body);
+	OnboardingResponse onboard(TryItNowDTO body);
+	boolean changePassword(Long id, UpdatePasswordDto body);
 }

--- a/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/service/SalaryRangeService.java
+++ b/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/service/SalaryRangeService.java
@@ -18,6 +18,8 @@ public interface SalaryRangeService {
 
     List<SalaryRange> findAll(Integer pageOffset);
 
+    List<SalaryRange> findAll();
+
     SalaryRange findOne(Long id);
 
     SalaryRange save(SalaryRangeDto body);

--- a/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/service/impl/OnboardingServiceImpl.java
+++ b/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/service/impl/OnboardingServiceImpl.java
@@ -1,0 +1,50 @@
+package com.hydraulic.applyforme.service.impl;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.hydraulic.applyforme.model.domain.Member;
+import com.hydraulic.applyforme.model.domain.ProfessionalProfile;
+import com.hydraulic.applyforme.model.dto.TryItNowDTO;
+import com.hydraulic.applyforme.model.response.OnboardingResponse;
+import com.hydraulic.applyforme.repository.MemberRepository;
+import com.hydraulic.applyforme.repository.ProfessionalProfileRepository;
+import com.hydraulic.applyforme.service.OnboardingService;
+import com.hydraulic.applyforme.util.ProfessionalProfileUtil;
+
+public class OnboardingServiceImpl implements OnboardingService {
+
+	@Autowired
+	private ModelMapper modelMapper;
+
+	private final MemberRepository memberRepository;
+	private final ProfessionalProfileRepository profileRepository;
+
+	public OnboardingServiceImpl(MemberRepository memberRepository, ProfessionalProfileRepository profileRepository) {
+		super();
+		this.memberRepository = memberRepository;
+		this.profileRepository = profileRepository;
+	}
+
+	@Override
+	public OnboardingResponse onboard(TryItNowDTO body) {
+		Member member = new Member();
+		member.setFirstName(body.getFirstName());
+		member.setLastName(body.getLastName());
+		member.setEmailAddress(body.getEmailAddress());
+		member.setPhoneNumber(body.getPhoneNumber());
+		memberRepository.saveOne(member);
+
+		ProfessionalProfile profile = new ProfessionalProfile();
+		profile.setDesiredJobTitle(body.getDesiredJobTitle());
+		profile.setSalaryRange(body.getSalaryRange());
+		profile.setYearsOfExperience(body.getYearsOfExperience());
+		profile.setEmploymentType(ProfessionalProfileUtil.getEmploymentType(body.getEmploymentType()));
+		profileRepository.saveOne(profile);
+
+		OnboardingResponse response = new OnboardingResponse();
+		modelMapper.map(body, response);
+		return response;
+	}
+
+}

--- a/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/service/impl/OnboardingServiceImpl.java
+++ b/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/service/impl/OnboardingServiceImpl.java
@@ -1,43 +1,70 @@
 package com.hydraulic.applyforme.service.impl;
 
+import java.util.Random;
+
+import javax.transaction.Transactional;
+
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
 
 import com.hydraulic.applyforme.model.domain.Member;
+import com.hydraulic.applyforme.model.domain.Professional;
 import com.hydraulic.applyforme.model.domain.ProfessionalProfile;
 import com.hydraulic.applyforme.model.dto.TryItNowDTO;
+import com.hydraulic.applyforme.model.dto.admin.UpdatePasswordDto;
 import com.hydraulic.applyforme.model.response.OnboardingResponse;
 import com.hydraulic.applyforme.repository.MemberRepository;
 import com.hydraulic.applyforme.repository.ProfessionalProfileRepository;
+import com.hydraulic.applyforme.repository.ProfessionalRepository;
 import com.hydraulic.applyforme.service.OnboardingService;
 import com.hydraulic.applyforme.util.ProfessionalProfileUtil;
 
+@Service
 public class OnboardingServiceImpl implements OnboardingService {
 
 	@Autowired
 	private ModelMapper modelMapper;
+	@Autowired
+	private PasswordEncoder encoder;
 
 	private final MemberRepository memberRepository;
 	private final ProfessionalProfileRepository profileRepository;
+	private final ProfessionalRepository professionalRepository;
 
-	public OnboardingServiceImpl(MemberRepository memberRepository, ProfessionalProfileRepository profileRepository) {
+	public OnboardingServiceImpl(MemberRepository memberRepository, 
+			ProfessionalProfileRepository profileRepository,
+			ProfessionalRepository professionalRepository) {
 		super();
 		this.memberRepository = memberRepository;
 		this.profileRepository = profileRepository;
+		this.professionalRepository = professionalRepository;
 	}
 
 	@Override
+	@Transactional
 	public OnboardingResponse onboard(TryItNowDTO body) {
 		Member member = new Member();
 		member.setFirstName(body.getFirstName());
 		member.setLastName(body.getLastName());
 		member.setEmailAddress(body.getEmailAddress());
 		member.setPhoneNumber(body.getPhoneNumber());
+		member.setPassword(encoder.encode(""+(int) Math.random()));
 		memberRepository.saveOne(member);
+		
+		Professional professional = Professional.builder()
+                .member(member)
+                .submissions(null) 
+                .professionalProfiles(null)
+                .build();
+		professionalRepository.saveOne(professional);
 
 		ProfessionalProfile profile = new ProfessionalProfile();
-		profile.setDesiredJobTitle(body.getDesiredJobTitle());
+		profile.setProfessional(professional);
+		profile.setProfileTitle(body.getProfileTitle());
 		profile.setSalaryRange(body.getSalaryRange());
+		profile.setJobLocation(body.getJobLocation());	
 		profile.setYearsOfExperience(body.getYearsOfExperience());
 		profile.setEmploymentType(ProfessionalProfileUtil.getEmploymentType(body.getEmploymentType()));
 		profileRepository.saveOne(profile);
@@ -45,6 +72,19 @@ public class OnboardingServiceImpl implements OnboardingService {
 		OnboardingResponse response = new OnboardingResponse();
 		modelMapper.map(body, response);
 		return response;
+	}
+
+	@Override
+	public boolean changePassword(Long id, UpdatePasswordDto body) {
+		Member member = memberRepository.getOne(id);
+		System.out.println(member.getPassword());
+		body.setExistingPassword(member.getPassword());
+		System.out.println(body.getNewPassword());
+		if(body.getNewPassword().equals(body.getConfirmationPassword())) {
+			member.setPassword(body.getConfirmationPassword());
+			return true;
+		}
+		return false;
 	}
 
 }

--- a/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/service/impl/SalaryRangeServiceImpl.java
+++ b/Apply-For-Me-Api/src/main/java/com/hydraulic/applyforme/service/impl/SalaryRangeServiceImpl.java
@@ -78,6 +78,11 @@ public class SalaryRangeServiceImpl implements SalaryRangeService {
     }
 
     @Override
+    public List<SalaryRange> findAll() {
+        return repository.getAll();
+    }
+
+    @Override
     public SalaryRange findOne(Long id) {
         SalaryRange salaryRange = repository.getOne(id);
         if (salaryRange == null) {


### PR DESCRIPTION
This is a feature to onboard a new user onto the website. I am trying to work on getting the user password changed as the implemetation gave the user a random password generated by math.random, which should be changed to what the user would later on want to use

LOGIC:
on click of submit button from the try-it-now signed up the user and gave a random password, the user gets an email to redirect them back to the webapp of which the URL includes the user ID of the user.

the user's id is captured and used to query the DB to fetch the existing password. the existiing password is then hidden from the user's screen but passed as body of the request sent to change the member's password. then user is in full control of their account